### PR TITLE
Add option to skip region verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ func NewMyCredentialsProvider() *MyCredentialsProvider {
 
 // (2) Create a combined V2/V4 verifier for S3 in us-east-1.
 // You can also create a standalone V2-only or V4-only verifier:
-v2v4 := awsig.NewV2V4(NewMyCredentialsProvider(), "us-east-1", "s3")
+v2v4 := awsig.NewV2V4(NewMyCredentialsProvider(), awsig.V4Config{
+	Region:  "us-east-1",
+	Service: "s3",
+})
 
 func …(w http.ResponseWriter, r *http.Request) {
 	// (3) Verify the incoming request:

--- a/v2v4.go
+++ b/v2v4.go
@@ -11,10 +11,10 @@ type V2V4 struct {
 	v4 *V4
 }
 
-func NewV2V4(provider CredentialsProvider, region, service string) *V2V4 {
+func NewV2V4(provider CredentialsProvider, v4Config V4Config) *V2V4 {
 	return &V2V4{
 		v2: NewV2(provider),
-		v4: NewV4(provider, region, service),
+		v4: NewV4(provider, v4Config),
 	}
 }
 

--- a/v2v4_test.go
+++ b/v2v4_test.go
@@ -7,7 +7,10 @@ import (
 
 func TestV2V4(t *testing.T) {
 	newV2V4 := func(provider CredentialsProvider, now func() time.Time) verifier[VerifiedRequest] {
-		v2v4 := NewV2V4(provider, testDefaultRegion, testDefaultService)
+		v2v4 := NewV2V4(provider, V4Config{
+			Region:  testDefaultRegion,
+			Service: testDefaultService,
+		})
 		v2v4.v2.now = now
 		v2v4.v4.now = now
 		return v2v4


### PR DESCRIPTION
This change introduces a configuration option for V4 signature verifiers that allows region verification to be skipped. Previously, the only acceptable region was that which was provided to the verifier's constructor.