### PR TITLE
fix V2 signature calculation issue caused by excluded query params

### DIFF
--- a/v2.go
+++ b/v2.go
@@ -264,15 +264,14 @@ func (v2 *V2[T]) calculateSignature(r *http.Request, dateElement, virtualHostedB
 			"delete":                       true,
 		}
 
+		maps.DeleteFunc(query, func(p string, _ []string) bool {
+			_, ok := included[p]
+			return !ok
+		})
 		queryParams := slices.Collect(maps.Keys(query))
 		slices.Sort(queryParams)
 
 		for i, p := range queryParams {
-			encode, ok := included[p]
-			if !ok {
-				continue
-			}
-
 			if i == 0 {
 				b.WriteByte('?')
 			}
@@ -284,7 +283,7 @@ func (v2 *V2[T]) calculateSignature(r *http.Request, dateElement, virtualHostedB
 				b.WriteString(p)
 				if v != "" {
 					b.WriteByte('=')
-					if encode {
+					if included[p] {
 						b.WriteString(uriEncode(v, false))
 					} else {
 						b.WriteString(v)

--- a/v2_test.go
+++ b/v2_test.go
@@ -97,6 +97,26 @@ func testV2[T VerifiedRequest[exampleAuthData]](t *testing.T, newV2 func(Credent
 		assert.That(t, n == 0)
 		assert.That(t, errors.Is(err, io.EOF))
 	})
+	t.Run("List versions", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "https://awsexamplebucket1.us-west-1.s3.amazonaws.com/?versions&prefix=photos&max-keys=50&marker=puppy", nil)
+		req.Header.Add("User-Agent", "Mozilla/5.0")
+		req.Header.Add("Date", "Tue, 27 Mar 2007 19:42:41 +0000")
+		req.Header.Add("Authorization", "AWS AKIAIOSFODNN7EXAMPLE:mi9g7igU2tMoWcHDpL4UcWKaf0I=")
+
+		v2 := newV2(provider, dummyNow(2007, time.March, 27, 19, 42, 41))
+
+		vr, err := v2.Verify(req, "awsexamplebucket1")
+		assert.NoError(t, err)
+		assert.Equal(t, accessKeyID, vr.AuthData().accessKeyID)
+
+		r, err := vr.Reader()
+		assert.NoError(t, err)
+
+		p := make([]byte, 32*1024)
+		n, err := r.Read(p)
+		assert.That(t, n == 0)
+		assert.That(t, errors.Is(err, io.EOF))
+	})
 	t.Run("Fetch", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://awsexamplebucket1.us-west-1.s3.amazonaws.com/?acl", nil)
 		req.Header.Add("Date", "Tue, 27 Mar 2007 19:44:46 +0000")


### PR DESCRIPTION
This change fixes an issue with the SigV2 signature calculation logic where the prefix symbol ("?" or "&") used when constructing the canonicalized resource string was sometimes incorrect.

Previously, the exclusion of irrelevant query paramerers was not taken into account when determining whether to prepend a "?" (for the first included parameter) or "&" (for the rest).

As a result, for URLs such as "?versions&max-keys=100", the "versions" parameter would be considered to have an index of 1 since it's lexicographically greater than "max-keys" despite "max-keys" being excluded. This would produce a canonicalized resource string with "&versions" rather than the expected "?versions".