### PR TITLE
properly handle X-Amz-Content-Sha256 header for V4 presigned URLs

### DIFF
--- a/util.go
+++ b/util.go
@@ -23,6 +23,8 @@ var (
 	ErrAuthorizationQueryParametersError = errors.New("the authorization query parameters that you provided are not valid")
 	// ErrBadDigest indicates the BadDigest error code.
 	ErrBadDigest = errors.New("the Content-MD5 or checksum value that you specified did not match what the server received")
+	// ErrInvalidXAmzContentSHA256 indicates that the value provided for the X-Amz-Content-Sha256 header is not valid.
+	ErrInvalidXAmzContentSHA256 = errors.New("the provided 'x-amz-content-sha256' header does not match what was computed")
 	// ErrEntityTooLarge indicates the EntityTooLarge error code.
 	ErrEntityTooLarge = errors.New("your proposed upload exceeds the maximum allowed object size")
 	// ErrEntityTooSmall indicates the EntityTooSmall error code.


### PR DESCRIPTION
This change ensures that the X-Amz-Content-Sha256 request header is properly handled for presigned URLs that use the SigV4 algorithm.

Previously, the value of this header was ignored, and any request with such a URL was assumed to have an unsigned payload. The default payload hash "UNSIGNED-PAYLOAD" was used in place of the payload hash specified in the request, which caused the server to calculate a different signature than the one provided, resulting in signature mismatch errors.

Additionally, because the payload hash specified in the request was ignored, no checksum verification was performed on the payload.