### PR TITLE
Add constant representing uninitialized checksum algorithm

### DIFF
--- a/integrity.go
+++ b/integrity.go
@@ -23,8 +23,10 @@ import (
 type ChecksumAlgorithm int
 
 const (
+	// AlgorithmNone represents an uninitialized checksum algorithm.
+	AlgorithmNone ChecksumAlgorithm = iota
 	// AlgorithmCRC32 represents the CRC-32 checksum algorithm.
-	AlgorithmCRC32 ChecksumAlgorithm = iota
+	AlgorithmCRC32
 	// AlgorithmCRC32C represents the CRC-32C checksum algorithm.
 	AlgorithmCRC32C
 	// AlgorithmCRC64NVME represents the CRC-64/NVME checksum algorithm.
@@ -61,6 +63,8 @@ func (a ChecksumAlgorithm) valid() bool {
 
 func (a ChecksumAlgorithm) String() string {
 	switch a {
+	case AlgorithmNone:
+		return "none"
 	case AlgorithmCRC32:
 		return "crc32"
 	case AlgorithmCRC32C:


### PR DESCRIPTION
This change changes the zero value of the checksum algorithm type to a constant representing an uninitialized checksum algorithm. This prevents logic errors where a variable of this type appears to have a value when it was simply never set. Previously, the zero value for the ChecksumAlgorithm type represented a valid checksum algorithm.